### PR TITLE
Add `documentTypeAdditional` character to get more info about document type

### DIFF
--- a/Sources/MRZParser/Private/MRZCode/MRZCodeFactory.swift
+++ b/Sources/MRZParser/Private/MRZCode/MRZCodeFactory.swift
@@ -67,7 +67,7 @@ struct MRZCodeFactory {
             namesField = formatter.createNamesField(from: thirdLine, at: 0, length: 29)
         case .td2, .td3:
             /// MRV-B and MRV-A types
-            let isVisaDocument =  MRZResult.DocumentType.visa.identifiers.contains(firstLine.substring(0, to: 0))
+            let isVisaDocument = firstLine.first == MRZResult.DocumentType.visa.identifier
 
             documentNumberField = formatter.createStringValidatedField(from: secondLine, at: 0, length: 9, fieldType: .documentNumber
             )

--- a/Sources/MRZParser/Public/MRZParser.swift
+++ b/Sources/MRZParser/Public/MRZParser.swift
@@ -28,14 +28,12 @@ public struct MRZParser {
 
         guard mrzCode.isValid else { return nil }
 
+        let documentType = mrzCode.documentTypeField.value
+
         return .init(
             format: format,
-            documentType: {
-                guard let documentTypeFirstElement = mrzCode.documentTypeField.value.first else { return .undefined }
-                return MRZResult.DocumentType.allCases.first(where: {
-                    $0.identifiers.contains(String(documentTypeFirstElement))
-                }) ?? .undefined
-            }(),
+            documentType: MRZResult.DocumentType.allCases.first { $0.identifier == documentType.first } ?? .undefined,
+            documentTypeAdditional: documentType.count == 2 ? documentType.last : nil,
             countryCode: mrzCode.countryCodeField.value,
             surnames: mrzCode.namesField.surnames,
             givenNames: mrzCode.namesField.givenNames,

--- a/Sources/MRZParser/Public/MRZResult.swift
+++ b/Sources/MRZParser/Public/MRZResult.swift
@@ -36,21 +36,18 @@ public struct MRZResult: Hashable {
         case visa
         case passport
         case id
-        case residencePermit
         case undefined
 
-        var identifiers: [String] {
+        var identifier: Character {
             switch self {
             case .visa:
-                return ["V"]
+                return "V"
             case .passport:
-                return ["P", "PN"]
+                return "P"
             case .id:
-                return ["I"]
-            case .residencePermit:
-                return ["IR"]
+                return "I"
             case .undefined:
-                return []
+                return "_"
             }
         }
     }
@@ -74,6 +71,7 @@ public struct MRZResult: Hashable {
 
     public let format: MRZFormat
     public let documentType: DocumentType
+    public let documentTypeAdditional: Character?
     public let countryCode: String
     public let surnames: String
     public let givenNames: String
@@ -89,6 +87,7 @@ public struct MRZResult: Hashable {
     public init(
         format: MRZFormat,
         documentType: DocumentType,
+        documentTypeAdditional: Character?,
         countryCode: String,
         surnames: String,
         givenNames: String,
@@ -102,6 +101,7 @@ public struct MRZResult: Hashable {
     ) {
         self.format = format
         self.documentType = documentType
+        self.documentTypeAdditional = documentTypeAdditional
         self.countryCode = countryCode
         self.surnames = surnames
         self.givenNames = givenNames

--- a/Tests/MRZParserTests/MRZParserTests.swift
+++ b/Tests/MRZParserTests/MRZParserTests.swift
@@ -33,6 +33,7 @@ final class MRZParserTests: XCTestCase {
         let result = MRZResult(
             format: .td1,
             documentType: .id,
+            documentTypeAdditional: nil,
             countryCode: "UTO",
             surnames: "ERIKSSON",
             givenNames: "ANNA MARIA",
@@ -50,12 +51,13 @@ final class MRZParserTests: XCTestCase {
 
     func testTD2() {
         let mrzString = """
-                        I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<
+                        IRUTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<
                         D231458907UTO7408122F1204159<<<<<<<6
                         """
         let result = MRZResult(
             format: .td2,
             documentType: .id,
+            documentTypeAdditional: "R",
             countryCode: "UTO",
             surnames: "ERIKSSON",
             givenNames: "ANNA MARIA",
@@ -79,6 +81,7 @@ final class MRZParserTests: XCTestCase {
         let result = MRZResult(
             format: .td3,
             documentType: .passport,
+            documentTypeAdditional: nil,
             countryCode: "UTO",
             surnames: "ERIKSSON",
             givenNames: "ANNA MARIA",
@@ -102,6 +105,7 @@ final class MRZParserTests: XCTestCase {
         let result = MRZResult(
             format: .td3,
             documentType: .passport,
+            documentTypeAdditional: nil,
             countryCode: "RUS",
             surnames: "IMIAREK",
             givenNames: "EVGENII",
@@ -125,6 +129,7 @@ final class MRZParserTests: XCTestCase {
         let result = MRZResult(
             format: .td3,
             documentType: .passport,
+            documentTypeAdditional: "N",
             countryCode: "RUS",
             surnames: "ZDRIL7K",
             givenNames: "SERGEQ ANATOL9EVI3",
@@ -148,6 +153,7 @@ final class MRZParserTests: XCTestCase {
         let result = MRZResult(
             format: .td3,
             documentType: .passport,
+            documentTypeAdditional: nil,
             countryCode: "NLD",
             surnames: "DE BRUIJN",
             givenNames: "WILLEKE LISELOTTE",
@@ -171,6 +177,7 @@ final class MRZParserTests: XCTestCase {
         let result = MRZResult(
             format: .td3,
             documentType: .visa,
+            documentTypeAdditional: nil,
             countryCode: "UTO",
             surnames: "ERIKSSON",
             givenNames: "ANNA MARIA",
@@ -194,6 +201,7 @@ final class MRZParserTests: XCTestCase {
         let result = MRZResult(
             format: .td2,
             documentType: .visa,
+            documentTypeAdditional: nil,
             countryCode: "UTO",
             surnames: "ERIKSSON",
             givenNames: "ANNA MARIA",


### PR DESCRIPTION
There are few document types with their identifiers represented with just 1 character (strictly listed).
But there might be a second character which is at the discretion of the issuing state or authority.

I made the `MRZResult` model more informative due to information above.

Here are some examples:
- Diplomatic passport could be marked as "PD";
- National passport could be marked as "P<" or "PN", depends on issuing authority;
- It might be "I<", "IR" or "IP" for identity cards, residence permits and passport cards respectively.